### PR TITLE
Fix multi-thread affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Multi-threaded benchmarks being spread across CPUs, instead of pinning the
+  main thread to CPU 0 and having all threads inherit the main thread's
+  affinity.
+
 ## [0.1.1] - 2023-10-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ divan-macros = { version = "0.1.1", path = "macros" }
 
 clap = { version = "4", default-features = false, features = ["std", "env"] }
 condtype = "1.3"
-core_affinity = { version = "0.8", default-features = false }
 regex = { package = "regex-lite", version = "0.1", default-features = false, features = ["std", "string"] }
 
 [target.'cfg(not(any(windows, target_os = "linux", target_os = "android")))'.dependencies]

--- a/src/divan.rs
+++ b/src/divan.rs
@@ -129,16 +129,6 @@ impl Divan {
         // Sorting is after filtering to compare fewer elements.
         EntryTree::sort_by_attr(&mut tree, self.sorting_attr, self.reverse_sort);
 
-        if action.is_bench() {
-            // Try pinning this thread's execution to the first CPU core to
-            // help reduce variance from scheduling.
-            if let Some(&[core_id, ..]) = core_affinity::get_core_ids().as_deref() {
-                if core_affinity::set_for_current(core_id) {
-                    eprintln!("Pinned thread to core {}", core_id.id);
-                };
-            }
-        }
-
         let timer = match self.timer {
             TimerKind::Os => Timer::Os,
 


### PR DESCRIPTION
This makes multi-threaded benchmarks be spread across CPUs, instead of pinning the main thread to CPU 0 and having all threads inherit the main thread's affinity.