### PR TITLE
Add setting global counters at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,10 @@ jobs:
         rust:
           - stable
           - nightly
+    env:
+      DIVAN_ITEMS_COUNT: 0
+      DIVAN_BYTES_COUNT: 1
+      DIVAN_CHARS_COUNT: 2
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v3.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Set global
+  [`Counter`s](https://docs.rs/divan/X.Y.Z/divan/counter/trait.Counter.html) at
+  runtime using:
+  - [`Divan::counter`](https://docs.rs/divan/X.Y.Z/divan/struct.Divan.html#method.counter)
+  - [`Divan::items_count`](https://docs.rs/divan/X.Y.Z/divan/struct.Divan.html#method.items_count)
+  - [`Divan::bytes_count`](https://docs.rs/divan/X.Y.Z/divan/struct.Divan.html#method.bytes_count)
+  - [`Divan::chars_count`](https://docs.rs/divan/X.Y.Z/divan/struct.Divan.html#method.chars_count)
+  - `--items-count N` CLI arg
+  - `--bytes-count N` CLI arg
+  - `--chars-count N` CLI arg
+  - `DIVAN_ITEMS_COUNT=N` env var
+  - `DIVAN_BYTES_COUNT=N` env var
+  - `DIVAN_CHARS_COUNT=N` env var
+
 - `From<C>` for
   [`ItemsCount`](https://docs.rs/divan/X.Y.Z/divan/counter/struct.ItemsCount.html),
   [`BytesCount`](https://docs.rs/divan/X.Y.Z/divan/counter/struct.BytesCount.html),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use clap::{builder::PossibleValue, value_parser, Arg, ArgAction, ColorChoice, Co
 
 use crate::{
     config::{ParsedSeconds, SortingAttr},
+    counter::MaxCountUInt,
     time::TimerKind,
 };
 
@@ -46,13 +47,6 @@ pub(crate) fn command() -> Command {
                 .value_name("WHEN")
                 .help("Controls when to use colors")
                 .value_parser(value_parser!(ColorChoice))
-        )
-        .arg(
-            option("bytes-format")
-                .env("DIVAN_BYTES_FORMAT")
-                .help("Set the numerical base for bytes in output")
-                .value_name("decimal|binary")
-                .value_parser(value_parser!(crate::counter::PrivBytesFormat))
         )
         .arg(
             option("skip")
@@ -124,6 +118,34 @@ pub(crate) fn command() -> Command {
                 .help("When '--min-time' or '--max-time' is set, skip time external to benchmarked functions")
                 .value_parser(value_parser!(bool))
                 .num_args(0..=1),
+        )
+        .arg(
+            option("items-count")
+                .env("DIVAN_ITEMS_COUNT")
+                .value_name("N")
+                .help("Set every benchmark to have a throughput of N items")
+                .value_parser(value_parser!(MaxCountUInt)),
+        )
+        .arg(
+            option("bytes-count")
+                .env("DIVAN_BYTES_COUNT")
+                .value_name("N")
+                .help("Set every benchmark to have a throughput of N bytes")
+                .value_parser(value_parser!(MaxCountUInt)),
+        )
+        .arg(
+            option("bytes-format")
+                .env("DIVAN_BYTES_FORMAT")
+                .help("Set the numerical base for bytes in output")
+                .value_name("decimal|binary")
+                .value_parser(value_parser!(crate::counter::PrivBytesFormat))
+        )
+        .arg(
+            option("chars-count")
+                .env("DIVAN_CHARS_COUNT")
+                .value_name("N")
+                .help("Set every benchmark to have a throughput of N string scalars")
+                .value_parser(value_parser!(MaxCountUInt)),
         )
         // ignored:
         .args([ignored_flag("bench"), ignored_flag("nocapture"), ignored_flag("show-output")])

--- a/src/counter/collection.rs
+++ b/src/counter/collection.rs
@@ -116,6 +116,11 @@ pub struct CounterSet {
 
 impl CounterSet {
     pub fn with(mut self, counter: impl IntoCounter) -> Self {
+        self.insert(counter);
+        self
+    }
+
+    pub fn insert(&mut self, counter: impl IntoCounter) -> &mut Self {
         let counter = AnyCounter::new(counter);
         self.counts[counter.known_kind() as usize] = Some(counter.count());
         self


### PR DESCRIPTION
Set global [`Counter`s](https://docs.rs/divan/0.1/divan/counter/trait.Counter.html) at runtime using:
  - `Divan::counter`
  - `Divan::items_count`
  - `Divan::bytes_count`
  - `Divan::chars_count`
  - `--items-count N` CLI arg
  - `--bytes-count N` CLI arg
  - `--chars-count N` CLI arg
  - `DIVAN_ITEMS_COUNT=N` env var
  - `DIVAN_BYTES_COUNT=N` env var
  - `DIVAN_CHARS_COUNT=N` env var