### PR TITLE
Reintroduce counter to search example benchmarks

### DIFF
--- a/examples/benches/search.rs
+++ b/examples/benches/search.rs
@@ -8,7 +8,12 @@ use fastrand::Rng;
 use ordsearch::OrderedCollection;
 
 fn main() {
-    divan::main();
+    divan::Divan::from_args()
+        .items_count(
+            // Every benchmark iteration searches for a single element.
+            1u32,
+        )
+        .main();
 }
 
 const SIZES: &[usize] =


### PR DESCRIPTION
Change 1713c6b (#24) removed the use of the `ItemsCount` counter because the resulting numbers didn't make much sense. So it was unreasonable to use the haystack size.

Every benchmark iteration searches for a single element, so it appears that the correct count to use is 1. The new throughput numbers now make more sense with this change.

Results:
- [Linux](https://github.com/nvzqz/divan/actions/runs/6793452049/job/18468306927#step:4:612)
- [macOS](https://github.com/nvzqz/divan/actions/runs/6793452049/job/18468307307#step:4:613)
- [Windows](https://github.com/nvzqz/divan/actions/runs/6793452049/job/18468307738#step:4:622)