### PR TITLE
WIP: JSON output with `--write` flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ divan-macros = { version = "0.1.2", path = "macros" }
 clap = { version = "4", default-features = false, features = ["std", "env"] }
 condtype = "1.3"
 regex = { package = "regex-lite", version = "0.1", default-features = false, features = ["std", "string"] }
+serde = { version = "1.0.192", features = ["derive"] }
+serde_json = "1.0.108"
+time = { version = "0.3.30", features = ["formatting"] }
 
 [target.'cfg(not(any(windows, target_os = "linux", target_os = "android")))'.dependencies]
 # We use linkme to make benchmark/group entries discoverable. On platforms where

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-env=OUT_DIR={}", std::env::var("OUT_DIR").unwrap());
+    println!("cargo:rustc-env=PROFILE={}", std::env::var("PROFILE").unwrap());
+}

--- a/src/bench/tests.rs
+++ b/src/bench/tests.rs
@@ -40,7 +40,7 @@ fn test_bencher(test: &mut dyn FnMut(Bencher)) {
     };
 
     for timer in Timer::available() {
-        for action in [Action::Bench, Action::Test] {
+        for action in [Action::Bench { write: false }, Action::Test] {
             let shared_context =
                 SharedContext { action, timer, bench_overhead: FineDuration::default() };
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,7 @@ pub(crate) fn command() -> Command {
     }
 
     // Custom arguments not supported by libtest:
+    // - write
     // - bytes-format
     // - sample-count
     // - sample-size
@@ -39,9 +40,11 @@ pub(crate) fn command() -> Command {
         .arg(
             flag("test")
                 .help("Run benchmarks once to ensure they run successfully")
-                .conflicts_with("list"),
+                .conflicts_with("list")
+                .conflicts_with("write"),
         )
-        .arg(flag("list").help("Lists benchmarks").conflicts_with("test"))
+        .arg(flag("list").help("Lists benchmarks").conflicts_with("test").conflicts_with("write"))
+        .arg(flag("write").help("Write test results to json file").conflicts_with("test").conflicts_with("list"))
         .arg(
             option("color")
                 .value_name("WHEN")

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,11 +15,10 @@ impl FromStr for ParsedSeconds {
 }
 
 /// The primary action to perform.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 pub(crate) enum Action {
     /// Run benchmark loops.
-    #[default]
-    Bench,
+    Bench { write: bool },
 
     /// Run benchmarked functions once to ensure they run successfully.
     Test,
@@ -28,11 +27,17 @@ pub(crate) enum Action {
     List,
 }
 
+impl Default for Action {
+    fn default() -> Self {
+        Action::Bench { write: false }
+    }
+}
+
 #[allow(dead_code)]
 impl Action {
     #[inline]
     pub fn is_bench(&self) -> bool {
-        matches!(self, Self::Bench)
+        matches!(self, Self::Bench { .. })
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod divan;
 mod entry;
 mod miri;
 mod stats;
+mod stats_collector;
 mod time;
 mod tree_painter;
 mod util;

--- a/src/private.rs
+++ b/src/private.rs
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(IntoThreads::into_threads(1), &[1]);
         assert_eq!(IntoThreads::into_threads(42), &[42]);
 
-        assert_eq!(IntoThreads::into_threads([0; 0]), &[]);
+        assert_eq!(IntoThreads::into_threads([0; 0]), &[] as &[usize]);
         assert_eq!(IntoThreads::into_threads([0]), &[0]);
         assert_eq!(IntoThreads::into_threads([0, 0]), &[0]);
 

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -10,6 +10,7 @@ mod sample;
 pub(crate) use sample::*;
 
 /// Statistics from samples.
+#[derive(serde::Serialize)]
 pub(crate) struct Stats {
     /// Total number of samples taken.
     pub sample_count: u32,
@@ -28,7 +29,7 @@ impl Stats {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub(crate) struct StatsSet<T> {
     /// Associated with minimum amount of time taken by an iteration.
     pub fastest: T,

--- a/src/stats_collector.rs
+++ b/src/stats_collector.rs
@@ -1,0 +1,101 @@
+use std::{collections::HashMap, error::Error};
+
+use crate::{
+    counter::{KnownCounterKind, MaxCountUInt},
+    entry::AnyBenchEntry,
+    stats::{Stats, StatsSet},
+};
+
+/// Collects tree-style statistics of benchmarks
+#[derive(Default)]
+pub(crate) struct StatsCollector {
+    path: Vec<String>,
+    stats: HashMap<String, JsonStats>,
+}
+
+impl StatsCollector {
+    pub(crate) fn enter_group(&mut self, group_name: String) {
+        self.path.push(group_name);
+    }
+
+    pub(crate) fn leave_group(&mut self) {
+        self.path.pop().unwrap();
+    }
+
+    pub(crate) fn add(&mut self, stats: Stats, entry: &AnyBenchEntry) {
+        self.stats.insert(self.path.join("."), JsonStats::from_stats(stats, entry));
+    }
+
+    pub(crate) fn write(&self) -> Result<(), Box<dyn Error>> {
+        eprintln!("Printing stats...");
+
+        let mut path = get_cargo_target_dir()?;
+        path.push("divan");
+        std::fs::create_dir_all(&path)?;
+
+        let time = time::OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Rfc3339)?;
+        path.push(time + ".json");
+
+        let writer = std::fs::File::create(path)?;
+        serde_json::to_writer(writer, &self.stats)?;
+
+        Ok(())
+    }
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct JsonStats {
+    pub display_name: String,
+    pub sample_count: u32,
+    pub iter_count: u64,
+    pub time: StatsSet<u128>,
+    pub counts: HashMap<&'static str, StatsSet<MaxCountUInt>>,
+}
+
+impl JsonStats {
+    pub(crate) fn from_stats(stats: Stats, entry: &AnyBenchEntry) -> Self {
+        Self {
+            display_name: entry.display_name().to_string(),
+            sample_count: stats.sample_count,
+            iter_count: stats.iter_count,
+            time: StatsSet {
+                fastest: stats.time.fastest.picos,
+                slowest: stats.time.slowest.picos,
+                median: stats.time.median.picos,
+                mean: stats.time.mean.picos,
+            },
+            counts: {
+                let mut map = HashMap::new();
+                if let Some(bytes) = &stats.counts[KnownCounterKind::Bytes as usize] {
+                    map.insert("bytes", bytes.clone());
+                }
+                if let Some(chars) = &stats.counts[KnownCounterKind::Chars as usize] {
+                    map.insert("chars", chars.clone());
+                }
+                if let Some(items) = &stats.counts[KnownCounterKind::Items as usize] {
+                    map.insert("items", items.clone());
+                }
+                map
+            },
+        }
+    }
+}
+
+fn get_cargo_target_dir() -> Result<std::path::PathBuf, Box<dyn Error>> {
+    let out_dir = std::path::PathBuf::from(env!("OUT_DIR"));
+    let profile = env!("PROFILE");
+    let mut target_dir = None;
+    let mut sub_path = out_dir.as_path();
+
+    while let Some(parent) = sub_path.parent() {
+        if parent.ends_with(profile) {
+            target_dir = Some(parent);
+            break;
+        }
+        sub_path = parent;
+    }
+
+    let target_dir = target_dir.ok_or("target directory not found")?;
+    Ok(target_dir.parent().unwrap().to_path_buf())
+}

--- a/src/time/fine_duration.rs
+++ b/src/time/fine_duration.rs
@@ -3,7 +3,7 @@ use std::{fmt, ops, time::Duration};
 use crate::util;
 
 /// [Picosecond](https://en.wikipedia.org/wiki/Picosecond)-precise [`Duration`].
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 #[repr(transparent)]
 pub(crate) struct FineDuration {
     pub picos: u128,

--- a/src/util.rs
+++ b/src/util.rs
@@ -143,7 +143,7 @@ mod tests {
     fn slice_middle() {
         use super::slice_middle;
 
-        assert_eq!(slice_middle::<i32>(&[]), &[]);
+        assert_eq!(slice_middle::<i32>(&[]), &[] as &[i32]);
 
         assert_eq!(slice_middle(&[1]), &[1]);
         assert_eq!(slice_middle(&[1, 2]), &[1, 2]);

--- a/tests/attr_options.rs
+++ b/tests/attr_options.rs
@@ -50,7 +50,7 @@ mod parent {
 
 #[test]
 fn iter_count() {
-    Divan::default().run_benches();
+    Divan::default().run_benches(false);
 
     assert_eq!(CHILD1_ITERS.load(SeqCst), 10);
     assert_eq!(CHILD2_ITERS.load(SeqCst), 2100);


### PR DESCRIPTION
Closes #10

When running `cargo bench -- --write`, produce a JSON file of the following shape:

```json
{
  "main.parse.strings": {
    "display_name": "strings",
    "sample_count": 100,
    "iter_count": 200,
    "time": {
      "fastest": 921251,
      "slowest": 1322751,
      "median": 954001,
      "mean": 980421
    },
    "counts": {
      "bytes": {
        "fastest": 60,
        "slowest": 60,
        "median": 60,
        "mean": 60
      }
    }
  },
  ...
}
```

for this benchmark:

```
main               fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ parse                         │               │               │               │         │
│  ╰─ strings      921.2 ns      │ 1.322 µs      │ 954 ns        │ 980.4 ns      │ 100     │ 200
│                  65.12 MB/s    │ 45.36 MB/s    │ 62.89 MB/s    │ 61.19 MB/s    │         │
...
```

The JSON file is written to `$CARGO_MANIFEST_PATH/target/divan/{time}.json`, where `{time}` is a RFC3339 formatted timestamp, e.g. `2023-11-12T22:12:00.231816795Z`.

I'm planning to create a web app to plot and compare different benchmarks, show changes over time, etc.

TODO:
- [ ] create a nested JSON object, instead of joining benchmark names with `.`
- [ ] make it an optional feature? (so users need `divan = { version = "*", features = ["json"] }` to opt-in)
- [ ] include info about the git revision (branch, tag, commit, commit date)?

Feedback is appreciated!