### PR TITLE
Profile allocations in benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- [`AllocProfiler`](https://docs.rs/divan/0.1.6/divan/struct.AllocProfiler.html)
+  allocator that tracks allocation counts and sizes during benchmarks.
+
 ## [0.1.5] - 2023-12-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,13 @@ readme = "README.md"
 [dependencies]
 divan-macros = { version = "0.1.5", path = "macros" }
 
+cfg-if = "1"
 clap = { version = "4", default-features = false, features = ["std", "env"] }
 condtype = "1.3"
 regex = { package = "regex-lite", version = "0.1", default-features = false, features = ["std", "string"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
 
 [dev-dependencies]
 mimalloc = "0.1"
@@ -35,3 +39,4 @@ members = ["macros", "examples", "internal_benches"]
 
 [workspace.dependencies]
 divan = { path = "." }
+libc = "0.2.148"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ clap = { version = "4", default-features = false, features = ["std", "env"] }
 condtype = "1.3"
 regex = { package = "regex-lite", version = "0.1", default-features = false, features = ["std", "string"] }
 
+[dev-dependencies]
+mimalloc = "0.1"
+
 [features]
 default = ["wrap_help"]
 help = ["clap/help"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -32,7 +32,7 @@ sha3 = { version = "0.10", optional = true }
 twox-hash = { version = "1.6", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.148"
+libc = { workspace = true }
 
 [target.'cfg(any(windows, target_os = "linux", target_os = "android"))'.dependencies]
 winapi = { version = "0.3.9", features = ["processthreadsapi"] }

--- a/examples/benches/collections.rs
+++ b/examples/benches/collections.rs
@@ -6,9 +6,12 @@
 
 use std::collections::{BTreeSet, BinaryHeap, HashSet, LinkedList, VecDeque};
 
-use divan::{black_box, Bencher};
+use divan::{black_box, AllocProfiler, Bencher};
 
 mod util;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     divan::main();

--- a/examples/benches/hash.rs
+++ b/examples/benches/hash.rs
@@ -5,6 +5,10 @@
 //! ```
 
 use digest::Digest;
+use divan::AllocProfiler;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     divan::main();

--- a/examples/benches/image.rs
+++ b/examples/benches/image.rs
@@ -6,8 +6,11 @@
 //! cargo bench -q -p examples --bench image --features image
 //! ```
 
-use divan::{black_box, counter::BytesCount, Bencher};
+use divan::{black_box, counter::BytesCount, AllocProfiler, Bencher};
 use image::{GenericImage, ImageBuffer, Rgba};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     divan::main();

--- a/examples/benches/panic.rs
+++ b/examples/benches/panic.rs
@@ -6,7 +6,10 @@
 
 use std::panic;
 
-use divan::{black_box, black_box_drop};
+use divan::{black_box, black_box_drop, AllocProfiler};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     // Silence panics.

--- a/examples/benches/search.rs
+++ b/examples/benches/search.rs
@@ -3,9 +3,12 @@ use std::{
     hash::BuildHasher,
 };
 
-use divan::{black_box_drop, Bencher};
+use divan::{black_box_drop, AllocProfiler, Bencher};
 use fastrand::Rng;
 use ordsearch::OrderedCollection;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     divan::Divan::from_args()

--- a/examples/benches/sort.rs
+++ b/examples/benches/sort.rs
@@ -4,8 +4,11 @@
 //! cargo bench -q -p examples --bench sort
 //! ```
 
-use divan::Bencher;
+use divan::{AllocProfiler, Bencher};
 use rayon::slice::ParallelSliceMut;
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     divan::main();

--- a/examples/benches/string.rs
+++ b/examples/benches/string.rs
@@ -7,8 +7,11 @@
 use divan::{
     black_box, black_box_drop,
     counter::{BytesCount, CharsCount},
-    Bencher,
+    AllocProfiler, Bencher,
 };
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     divan::main();

--- a/examples/benches/threads.rs
+++ b/examples/benches/threads.rs
@@ -13,7 +13,10 @@ use std::{
     thread::{Thread, ThreadId},
 };
 
-use divan::{black_box, black_box_drop, Bencher};
+use divan::{black_box, black_box_drop, AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     divan::main();

--- a/examples/benches/time.rs
+++ b/examples/benches/time.rs
@@ -6,7 +6,10 @@
 
 use std::time::{Instant, SystemTime};
 
-use divan::Bencher;
+use divan::{AllocProfiler, Bencher};
+
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
 
 fn main() {
     divan::main();

--- a/internal_benches/benches/internals.rs
+++ b/internal_benches/benches/internals.rs
@@ -1,3 +1,8 @@
+use divan::AllocProfiler;
+
+#[global_allocator]
+static GLOBAL_ALLOC: AllocProfiler = AllocProfiler::system();
+
 fn main() {
     divan::main();
 }

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,0 +1,564 @@
+use std::{
+    alloc::*,
+    cell::Cell,
+    ptr::{self, NonNull},
+    sync::atomic::{AtomicPtr, Ordering::*},
+};
+
+use crate::{
+    stats::StatsSet,
+    util::{self, LocalCount, SharedCount},
+};
+
+// Use `AllocProfiler` when running crate-internal tests. This enables us to
+// test it for undefined behavior with Miri.
+#[cfg(test)]
+#[global_allocator]
+static ALLOC: AllocProfiler = AllocProfiler::system();
+
+/// Initializes the current thread's allocation information object.
+///
+/// Note that despite the work done here, we still initialize thread-local alloc
+/// info in the `GlobalAlloc` implementation for `Alloc` because benchmarks can
+/// allocate their own threads.
+pub(crate) fn init_current_thread_info() {
+    // Allocate the info object using the `System` allocator since that's
+    // convenient in this context. We may want to use the true global allocator
+    // instead.
+    AllocProfiler::system().current_thread_info().make_reusable();
+}
+
+/// Measures [`GlobalAlloc`] memory usage.
+///
+/// # Examples
+///
+/// The default usage is to create a
+/// [`#[global_allocator]`](macro@global_allocator) that wraps the [`System`]
+/// allocator with [`AllocProfiler::system()`]:
+///
+/// ```
+/// use std::collections::*;
+/// use divan::AllocProfiler;
+///
+/// #[global_allocator]
+/// static ALLOC: AllocProfiler = AllocProfiler::system();
+///
+/// fn main() {
+///     divan::main();
+/// }
+///
+/// #[divan::bench(types = [
+///     Vec<i32>,
+///     LinkedList<i32>,
+///     HashSet<i32>,
+/// ])]
+/// fn from_iter<T>() -> T
+/// where
+///     T: FromIterator<i32>,
+/// {
+///     (0..100).collect()
+/// }
+///
+/// #[divan::bench(types = [
+///     Vec<i32>,
+///     LinkedList<i32>,
+///     HashSet<i32>,
+/// ])]
+/// fn drop<T>(bencher: divan::Bencher)
+/// where
+///     T: FromIterator<i32>,
+/// {
+///     bencher
+///         .with_inputs(|| (0..100).collect::<T>())
+///         .bench_values(std::mem::drop);
+/// }
+/// ```
+///
+/// Wrap other [`GlobalAlloc`] implementations like
+/// [`mimalloc`](https://docs.rs/mimalloc) with [`AllocProfiler::new()`]:
+///
+/// ```
+/// use divan::AllocProfiler;
+/// use mimalloc::MiMalloc;
+///
+/// # #[cfg(not(miri))]
+/// #[global_allocator]
+/// static ALLOC: AllocProfiler<MiMalloc> = AllocProfiler::new(MiMalloc);
+/// ```
+///
+/// See [`string`](https://github.com/nvzqz/divan/blob/main/examples/benches/string.rs)
+/// and [`collections`](https://github.com/nvzqz/divan/blob/main/examples/benches/collections.rs)
+/// benchmarks for more examples.
+///
+/// # Implementation
+///
+/// Allocation information is recorded in thread-local storage to prevent
+/// contention when benchmarks involve multiple threads, either internally or
+/// through options like [`threads`](macro@crate::bench#threads). This is
+/// currently achieved with the portable [`thread_local!`] macro. To reduce
+/// Divan's footprint, the implementation in the future will take advantage of
+/// faster platform-specific approaches, such as
+/// [`pthread_getspecific`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_getspecific.html)
+/// on macOS.
+#[derive(Debug, Default)]
+pub struct AllocProfiler<Alloc = System> {
+    alloc: Alloc,
+}
+
+unsafe impl<A: GlobalAlloc> GlobalAlloc for AllocProfiler<A> {
+    // NOTE: Within `alloc` we can't access `REUSE_THREAD_INFO` because
+    // thread-locals with `Drop` crash:
+    // https://github.com/rust-lang/rust/issues/116390.
+    //
+    // To get around this, we initialize the drop handle at two locations:
+    // 1. Within `sync_threads` immediately before the sample loop. This covers
+    //    all benchmarks that don't spawn their own threads, so most of them.
+    // 2. Within `dealloc` since it will likely be called before thread
+    //    termination.
+
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // Tally allocation count.
+        self.current_thread_info().tally(AllocOp::Alloc, layout.size());
+
+        self.alloc.alloc(layout)
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // Tally allocation count.
+        self.current_thread_info().tally(AllocOp::Alloc, layout.size());
+
+        self.alloc.alloc_zeroed(layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: `ptr` must come from this allocator, so we can assume
+        // thread-local info has been initialized during allocation.
+        let info = unsafe { CURRENT_THREAD_INFO.get().unwrap_unchecked() };
+
+        // Tally reallocation count.
+        let shrink = new_size < layout.size();
+        info.tally(
+            AllocOp::realloc(shrink),
+            if shrink { layout.size() - new_size } else { new_size - layout.size() },
+        );
+
+        self.alloc.realloc(ptr, layout, new_size)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` must come from this allocator, so we can assume
+        // thread-local info has been initialized during allocation.
+        let info = unsafe { CURRENT_THREAD_INFO.get().unwrap_unchecked() };
+
+        // Enable info to be reused after thread termination.
+        info.make_reusable();
+
+        // Tally deallocation count.
+        info.tally(AllocOp::Dealloc, layout.size());
+
+        self.alloc.dealloc(ptr, layout)
+    }
+}
+
+impl AllocProfiler {
+    /// Profiles the [`System`] allocator.
+    #[inline]
+    pub const fn system() -> Self {
+        Self::new(System)
+    }
+}
+
+impl<A> AllocProfiler<A> {
+    /// Profiles a [`GlobalAlloc`].
+    #[inline]
+    pub const fn new(alloc: A) -> Self {
+        Self { alloc }
+    }
+}
+
+impl<A: GlobalAlloc> AllocProfiler<A> {
+    #[inline]
+    fn current_thread_info(&self) -> &'static ThreadAllocInfo {
+        CURRENT_THREAD_INFO.with(|local_info| match local_info.get() {
+            Some(info) => info,
+
+            // PERF: Don't provide `local_info` to the helper because doing so
+            // generates more code here.
+            None => self.current_thread_info_slow(),
+        })
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn current_thread_info_slow(&self) -> &'static ThreadAllocInfo {
+        let info = 'info: {
+            // Attempt to reuse a previously-allocated instance from a terminated
+            // thread relinquishing its claim on this allocation.
+            if let Some(info) = ALL_THREAD_INFO.pop_reuse_list() {
+                break 'info info;
+            }
+
+            // Allocate a new instance since none are available for reuse.
+            //
+            // We do not report this allocation because it was not invoked by the
+            // benchmarked code.
+            unsafe {
+                let info: *mut ThreadAllocInfo =
+                    self.alloc.alloc_zeroed(Layout::new::<ThreadAllocInfo>()).cast();
+
+                // Default to global instance on allocation failure.
+                if info.is_null() {
+                    break 'info &ALL_THREAD_INFO;
+                }
+
+                // This allocation is reused by setting `ALL_THREAD_INFO.reuse_next`
+                // to `info` on thread termination via `REUSE_THREAD_INFO` drop.
+                util::miri::leak(info);
+
+                // Make `info` discoverable by pushing it onto the global
+                // linked list as the new head.
+                let mut current_head = ALL_THREAD_INFO.next.load(Acquire);
+                loop {
+                    // Prepare `current_head` to become second node in the list.
+                    (*info).next = AtomicPtr::new(current_head);
+
+                    // Replace head node with `info`.
+                    match ALL_THREAD_INFO.next.compare_exchange(current_head, info, AcqRel, Acquire)
+                    {
+                        // Successfully set our list head.
+                        Ok(_) => {
+                            let info = &*info;
+                            break 'info info;
+                        }
+
+                        // Other thread set their list head.
+                        Err(their_head) => current_head = their_head,
+                    }
+                }
+            }
+        };
+
+        CURRENT_THREAD_INFO.set(Some(info));
+
+        info
+    }
+}
+
+/// Thread-local allocation information.
+///
+/// This represents a tree consisting of two independent linked-lists:
+/// - `next` stores all instances.
+/// - `reuse_next` stores reusable instances from terminated threads.
+pub(crate) struct ThreadAllocInfo {
+    pub tallies: SharedAllocTallyMap,
+
+    /// The next instance in a global linked list.
+    ///
+    /// `ALL_THREAD_INFO` is the head of a global linked list that is only ever
+    /// pushed to access all instances that have ever been created in order to
+    /// accumulate stats.
+    ///
+    /// This field is initialized at most once.
+    next: AtomicPtr<ThreadAllocInfo>,
+
+    /// The next available instance for reuse.
+    ///
+    /// `ALL_THREAD_INFO.reuse_count` is the head of a global linked list that
+    /// can be popped to reuse previously-allocated instances.
+    ///
+    /// This may be set to 1 to indicate `REUSE_THREAD_INFO` has been
+    /// initialized. See `ThreadAllocInfo::make_reusable`.
+    reuse_next: AtomicPtr<ThreadAllocInfo>,
+}
+
+/// Reclaims `ThreadAllocInfo` allocations on `Drop`.
+///
+/// This avoids allocating new thread info and pushing it to
+/// `ALL_THREAD_INFO.next`.
+struct ThreadInfoReuseHandle {
+    info: &'static ThreadAllocInfo,
+}
+
+impl Drop for ThreadInfoReuseHandle {
+    #[inline]
+    fn drop(&mut self) {
+        let mut current_head = ALL_THREAD_INFO.reuse_next.load(Acquire);
+
+        loop {
+            // Prepare `current_head` to become second node in the list.
+            self.info.reuse_next.store(current_head, Relaxed);
+
+            // Replace head node with `our_head`.
+            match ALL_THREAD_INFO.reuse_next.compare_exchange(
+                current_head,
+                self.info as *const _ as *mut _,
+                AcqRel,
+                Acquire,
+            ) {
+                // We updated `self.reuse_next`.
+                Ok(_) => return,
+
+                Err(their_head) => current_head = their_head,
+            }
+        }
+    }
+}
+
+thread_local! {
+    /// Instance specific to the current thread.
+    static CURRENT_THREAD_INFO: Cell<Option<&'static ThreadAllocInfo>> = const { Cell::new(None) };
+}
+
+thread_local! {
+    /// When a thread terminates, this will be dropped and the allocation will
+    /// be reclaimed for reuse.
+    static REUSE_THREAD_INFO: Cell<Option<ThreadInfoReuseHandle>> = const { Cell::new(None) };
+}
+
+/// Global instance for thread information.
+///
+/// This is used as:
+/// - The start of the linked list of all info instances.
+/// - The owner of the linked list of reusable info instances.
+/// - A last-resort instance on allocation failure.
+static ALL_THREAD_INFO: ThreadAllocInfo = ThreadAllocInfo {
+    tallies: SharedAllocTallyMap::EMPTY,
+    next: AtomicPtr::new(ptr::null_mut()),
+    reuse_next: AtomicPtr::new(ptr::null_mut()),
+};
+
+impl ThreadAllocInfo {
+    #[inline]
+    pub fn all() -> impl Iterator<Item = &'static Self> {
+        std::iter::successors(Some(&ALL_THREAD_INFO), |current| unsafe {
+            current.next.load(Acquire).as_ref()
+        })
+    }
+
+    /// Returns the current thread's allocation information if initialized.
+    #[inline]
+    pub fn try_current() -> Option<&'static Self> {
+        CURRENT_THREAD_INFO.get()
+    }
+
+    /// Sets 0 to all values.
+    pub fn clear(&self) {
+        for value in &self.tallies.values {
+            value.count.store(0, Relaxed);
+            value.size.store(0, Relaxed);
+        }
+    }
+
+    /// Tallies the total count and size of the allocation operation.
+    #[inline]
+    fn tally(&self, op: AllocOp, size: usize) {
+        let tally = self.tallies.get(op);
+        tally.count.fetch_add(1, Relaxed);
+        tally.size.fetch_add(size as LocalCount, Relaxed);
+    }
+
+    /// Registers `self` with `REUSE_THREAD_INFO` so that it can be reused on
+    /// thread termination via `Drop` of `ThreadInfoReuseHandle`.
+    #[inline]
+    fn make_reusable(&'static self) {
+        // This is 1 from `ptr::from_exposed_addr`, but usable in stable.
+        const IS_REUSABLE: *mut u8 = NonNull::dangling().as_ptr();
+
+        // PERF: We check `reuse_next` pointer instead of always accessing
+        // `REUSE_THREAD_INFO` because:
+        // - We reduce code emitted in `Alloc::dealloc` by using a separate
+        //   function for thread-local access and dtor initialization.
+        // - Thread-local access always goes through a function call, whereas an
+        //   atomic load is about as fast as a non-synchronized load.
+        //
+        // Relaxed loads are fine here because we're not accessing memory
+        // through the pointer.
+        if self.reuse_next.load(Relaxed).cast() != IS_REUSABLE {
+            slow_impl(self);
+        }
+
+        #[cold]
+        fn slow_impl(info: &'static ThreadAllocInfo) {
+            // Although it is unlikely we fail to allocate and use the global
+            // instance, skip it in case.
+            if ptr::eq(info, &ALL_THREAD_INFO) {
+                return;
+            }
+
+            // Initialize dtor for thread-local.
+            //
+            // If this is being called during `dealloc` on thread termination,
+            // then the thread info will be leaked.
+            _ = REUSE_THREAD_INFO.try_with(|local| local.set(Some(ThreadInfoReuseHandle { info })));
+
+            // Mark as claimed for reuse.
+            info.reuse_next.store(IS_REUSABLE.cast(), Relaxed);
+        }
+    }
+
+    /// Pops the head element off of the `reuse_next` linked list.
+    ///
+    /// When a thread terminates, `REUSE_THREAD_INFO` will relinquish this
+    /// thread's claim on its `ThreadAllocInfo` instance by pushing it onto the
+    /// `ALL_THREAD_INFO.reuse_next` linked list. This method reclaims the
+    /// instance for the current thread.
+    #[inline]
+    fn pop_reuse_list(&self) -> Option<&'static ThreadAllocInfo> {
+        unsafe {
+            let mut current_head = self.reuse_next.load(Relaxed);
+
+            loop {
+                let current = match current_head as usize {
+                    0 | 1 => return None,
+                    _ => &*current_head,
+                };
+
+                // Replace `current_head` with its next node.
+                let our_head = current.reuse_next.load(Relaxed);
+                match self.reuse_next.compare_exchange(current_head, our_head, AcqRel, Acquire) {
+                    // Successfully set our list head.
+                    Ok(_) => return Some(current),
+
+                    // Other thread set their list head.
+                    Err(their_head) => current_head = their_head,
+                }
+            }
+        }
+    }
+}
+
+/// Allocation numbers being accumulated.
+///
+/// This uses [`SharedCount`], which is `AtomicU64` (if available) or
+/// `AtomicUsize`.
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+pub(crate) struct AllocTally<Count> {
+    /// The number of times this operation was performed.
+    pub count: Count,
+
+    /// The amount of memory this operation changed.
+    pub size: Count,
+}
+
+pub(crate) type SharedAllocTally = AllocTally<SharedCount>;
+
+pub(crate) type LocalAllocTally = AllocTally<LocalCount>;
+
+pub(crate) type TotalAllocTally = AllocTally<u128>;
+
+impl LocalAllocTally {
+    #[inline]
+    pub fn is_zero(&self) -> bool {
+        self.count == 0 && self.size == 0
+    }
+}
+
+impl AllocTally<StatsSet<f64>> {
+    pub fn is_zero(&self) -> bool {
+        self.count.is_zero() && self.size.is_zero()
+    }
+}
+
+impl<C> AllocTally<C> {
+    #[inline]
+    pub fn as_array(&self) -> &[C; 2] {
+        // SAFETY: This is `#[repr(C)]`, so we can treat it as a contiguous
+        // sequence of items.
+        unsafe { &*(self as *const _ as *const _) }
+    }
+}
+
+/// Allocation number categories.
+///
+/// Note that grow/shrink are first to improve code generation for `realloc`.
+#[derive(Clone, Copy)]
+pub(crate) enum AllocOp {
+    Grow,
+    Shrink,
+    Alloc,
+    Dealloc,
+}
+
+impl AllocOp {
+    pub const ALL: [Self; 4] = {
+        use AllocOp::*;
+
+        // Use same order as declared so that it can be indexed as-is.
+        [Grow, Shrink, Alloc, Dealloc]
+    };
+
+    #[inline]
+    pub fn realloc(shrink: bool) -> Self {
+        // This generates the same code as `std::mem::transmute`.
+        if shrink {
+            Self::Shrink
+        } else {
+            Self::Grow
+        }
+    }
+
+    #[inline]
+    pub fn prefix(self) -> &'static str {
+        match self {
+            Self::Grow => "grow:",
+            Self::Shrink => "shrink:",
+            Self::Alloc => "alloc:",
+            Self::Dealloc => "dealloc:",
+        }
+    }
+}
+
+/// Values keyed by `AllocOp`.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct AllocOpMap<T> {
+    pub values: [T; 4],
+}
+
+pub(crate) type SharedAllocTallyMap = AllocOpMap<SharedAllocTally>;
+
+pub(crate) type LocalAllocTallyMap = AllocOpMap<LocalAllocTally>;
+
+pub(crate) type TotalAllocTallyMap = AllocOpMap<TotalAllocTally>;
+
+impl SharedAllocTallyMap {
+    /// A map with all values set to 0.
+    #[allow(clippy::declare_interior_mutable_const)]
+    pub const EMPTY: Self = {
+        const ZERO: SharedAllocTally =
+            SharedAllocTally { size: SharedCount::new(0), count: SharedCount::new(0) };
+
+        Self { values: [ZERO; 4] }
+    };
+
+    pub fn load(&self) -> LocalAllocTallyMap {
+        LocalAllocTallyMap {
+            values: AllocOp::ALL.map(|op| {
+                let value = &self.values[op as usize];
+                AllocTally { count: value.count.load(Relaxed), size: value.size.load(Relaxed) }
+            }),
+        }
+    }
+}
+
+impl LocalAllocTallyMap {
+    /// Returns `true` if all tallies are 0.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.values.iter().all(LocalAllocTally::is_zero)
+    }
+
+    pub fn add_to_total(&self, total: &mut TotalAllocTallyMap) {
+        for (i, value) in self.values.iter().enumerate() {
+            total.values[i].count += value.count as u128;
+            total.values[i].size += value.size as u128;
+        }
+    }
+}
+
+impl<T> AllocOpMap<T> {
+    #[inline]
+    pub const fn get(&self, op: AllocOp) -> &T {
+        &self.values[op as usize]
+    }
+}

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -876,7 +876,7 @@ impl<'a> BenchContext<'a> {
 
             let mut sum_alloc_tallies = || {
                 if let Some(alloc_info) = alloc_info {
-                    alloc_tallies = alloc_info.tallies.load();
+                    alloc_tallies = alloc_info.tallies.0.load();
                 }
             };
 

--- a/src/bench/tests.rs
+++ b/src/bench/tests.rs
@@ -60,7 +60,7 @@ fn test_bencher(test: &mut dyn FnMut(Bencher)) {
                 // '--test' should run the expected number of times but not
                 // allocate any samples.
                 if action.is_test() {
-                    assert_eq!(samples.all.capacity(), 0);
+                    assert_eq!(samples.time_samples.capacity(), 0);
                 }
 
                 if action.is_test() || thread_count == 1 {
@@ -70,7 +70,7 @@ fn test_bencher(test: &mut dyn FnMut(Bencher)) {
                 if thread_count > 1 {
                     assert_eq!(
                         samples.threads.len() * thread_count,
-                        samples.all.len(),
+                        samples.time_samples.len(),
                         "Thread sample count must be a multiple of total sample count"
                     );
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 #[path = "private.rs"]
 pub mod __private;
 
+mod alloc;
 mod bench;
 mod cli;
 mod compile_fail;
@@ -27,7 +28,7 @@ pub mod counter;
 pub use std::hint::black_box;
 
 #[doc(inline)]
-pub use crate::{bench::Bencher, divan::Divan};
+pub use crate::{alloc::AllocProfiler, bench::Bencher, divan::Divan};
 
 /// Runs all registered benchmarks.
 ///

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,6 +1,7 @@
 //! Measurement statistics.
 
 use crate::{
+    alloc::{AllocOpMap, AllocTally},
     counter::{KnownCounterKind, MaxCountUInt},
     time::FineDuration,
 };
@@ -17,8 +18,14 @@ pub(crate) struct Stats {
     /// Total number of iterations (currently `sample_count * `sample_size`).
     pub iter_count: u64,
 
+    /// Timing statistics.
     pub time: StatsSet<FineDuration>,
 
+    /// Allocation statistics associated with the corresponding samples for
+    /// `time`.
+    pub alloc_tallies: AllocOpMap<AllocTally<StatsSet<f64>>>,
+
+    /// `Counter` counts associated with the corresponding samples for `time`.
     pub counts: [Option<StatsSet<MaxCountUInt>>; KnownCounterKind::COUNT],
 }
 
@@ -41,4 +48,10 @@ pub(crate) struct StatsSet<T> {
 
     /// Associated with average time taken by all iterations.
     pub mean: T,
+}
+
+impl StatsSet<f64> {
+    pub fn is_zero(&self) -> bool {
+        self.fastest == 0.0 && self.slowest == 0.0 && self.median == 0.0 && self.mean == 0.0
+    }
 }

--- a/src/time/fine_duration.rs
+++ b/src/time/fine_duration.rs
@@ -52,7 +52,7 @@ impl fmt::Display for FineDuration {
                 // Multiply to allow `sig_figs` digits of fractional precision.
                 let val = (((picos * multiple) / scale.picos()) as f64) / multiple as f64;
 
-                util::format_f64(val, sig_figs)
+                util::fmt::format_f64(val, sig_figs)
             }
         };
 

--- a/src/util/fmt.rs
+++ b/src/util/fmt.rs
@@ -1,0 +1,220 @@
+use std::fmt;
+
+use crate::counter::{AnyCounter, BytesFormat, KnownCounterKind};
+
+/// Formats an `f64` to the given number of significant figures.
+pub(crate) fn format_f64(val: f64, sig_figs: usize) -> String {
+    let mut str = val.to_string();
+
+    if let Some(dot_index) = str.find('.') {
+        let fract_digits = sig_figs.saturating_sub(dot_index);
+
+        if fract_digits == 0 {
+            str.truncate(dot_index);
+        } else {
+            let fract_start = dot_index + 1;
+            let fract_end = fract_start + fract_digits;
+            let fract_range = fract_start..fract_end;
+
+            if let Some(fract_str) = str.get(fract_range) {
+                // Get the offset from the end before all 0s.
+                let pre_zero = fract_str.bytes().rev().enumerate().find_map(|(i, b)| {
+                    if b != b'0' {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                });
+
+                if let Some(pre_zero) = pre_zero {
+                    str.truncate(fract_end - pre_zero);
+                } else {
+                    str.truncate(dot_index);
+                }
+            }
+        }
+    }
+
+    str
+}
+
+pub(crate) fn format_bytes(val: f64, sig_figs: usize, bytes_format: BytesFormat) -> String {
+    let (val, scale) = scale_value(val, bytes_format);
+
+    let mut result = format_f64(val, sig_figs);
+    result.push(' ');
+    result.push_str(scale.suffix(ScaleFormat::Bytes(bytes_format)));
+    result
+}
+
+pub(crate) struct DisplayThroughput<'a> {
+    pub counter: &'a AnyCounter,
+    pub picos: f64,
+    pub bytes_format: BytesFormat,
+}
+
+impl fmt::Debug for DisplayThroughput<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for DisplayThroughput<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let picos = self.picos;
+        let count = self.counter.count();
+        let count_per_sec = if count == 0 { 0. } else { count as f64 * (1e12 / picos) };
+
+        let format = match self.counter.kind {
+            KnownCounterKind::Bytes => ScaleFormat::BytesThroughput(self.bytes_format),
+            KnownCounterKind::Chars => ScaleFormat::CharsThroughput,
+            KnownCounterKind::Items => ScaleFormat::ItemsThroughput,
+        };
+
+        let (val, scale) = scale_value(count_per_sec, format.bytes_format());
+
+        let sig_figs = f.precision().unwrap_or(4);
+
+        let mut str = format_f64(val, sig_figs);
+        str.push(' ');
+        str.push_str(scale.suffix(format));
+
+        // Fill up to specified width.
+        if let Some(fill_len) = f.width().and_then(|width| width.checked_sub(str.len())) {
+            match f.align() {
+                None | Some(fmt::Alignment::Left) => {
+                    str.extend(std::iter::repeat(f.fill()).take(fill_len));
+                }
+                _ => return Err(fmt::Error),
+            }
+        }
+
+        f.write_str(&str)
+    }
+}
+
+/// Converts a value to the appropriate scale.
+fn scale_value(value: f64, bytes_format: BytesFormat) -> (f64, Scale) {
+    let starts = scale_starts(bytes_format);
+
+    let scale = if value.is_infinite() || value < starts[1] {
+        Scale::One
+    } else if value < starts[2] {
+        Scale::Kilo
+    } else if value < starts[3] {
+        Scale::Mega
+    } else if value < starts[4] {
+        Scale::Giga
+    } else if value < starts[5] {
+        Scale::Tera
+    } else {
+        Scale::Peta
+    };
+
+    (value / starts[scale as usize], scale)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Scale {
+    One,
+    Kilo,
+    Mega,
+    Giga,
+    Tera,
+    Peta,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum ScaleFormat {
+    Bytes(BytesFormat),
+    BytesThroughput(BytesFormat),
+    CharsThroughput,
+    ItemsThroughput,
+}
+
+impl ScaleFormat {
+    pub fn bytes_format(self) -> BytesFormat {
+        match self {
+            Self::Bytes(format) | Self::BytesThroughput(format) => format,
+            Self::CharsThroughput | Self::ItemsThroughput => BytesFormat::Decimal,
+        }
+    }
+}
+
+fn scale_starts(bytes_format: BytesFormat) -> &'static [f64; Scale::COUNT] {
+    const STARTS: &[[f64; Scale::COUNT]; 2] = &[
+        [1., 1e3, 1e6, 1e9, 1e12, 1e15],
+        [
+            1.,
+            1024.,
+            1024u64.pow(2) as f64,
+            1024u64.pow(3) as f64,
+            1024u64.pow(4) as f64,
+            1024u64.pow(5) as f64,
+        ],
+    ];
+
+    &STARTS[bytes_format as usize]
+}
+
+impl Scale {
+    const COUNT: usize = 6;
+
+    pub fn suffix(self, format: ScaleFormat) -> &'static str {
+        match format {
+            ScaleFormat::Bytes(format) => {
+                const SUFFIXES: &[[&str; Scale::COUNT]; 2] = &[
+                    ["B", "KB", "MB", "GB", "TB", "PB"],
+                    ["B", "KiB", "MiB", "GiB", "TiB", "PiB"],
+                ];
+
+                SUFFIXES[format as usize][self as usize]
+            }
+            ScaleFormat::BytesThroughput(format) => {
+                const SUFFIXES: &[[&str; Scale::COUNT]; 2] = &[
+                    ["B/s", "KB/s", "MB/s", "GB/s", "TB/s", "PB/s"],
+                    ["B/s", "KiB/s", "MiB/s", "GiB/s", "TiB/s", "PiB/s"],
+                ];
+
+                SUFFIXES[format as usize][self as usize]
+            }
+            ScaleFormat::CharsThroughput => {
+                const SUFFIXES: &[&str; Scale::COUNT] =
+                    &["char/s", "Kchar/s", "Mchar/s", "Gchar/s", "Tchar/s", "Pchar/s"];
+
+                SUFFIXES[self as usize]
+            }
+            ScaleFormat::ItemsThroughput => {
+                const SUFFIXES: &[&str; Scale::COUNT] =
+                    &["item/s", "Kitem/s", "Mitem/s", "Gitem/s", "Titem/s", "Pitem/s"];
+
+                SUFFIXES[self as usize]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scale_value() {
+        #[track_caller]
+        fn test(n: f64, format: BytesFormat, expected_value: f64, expected_scale: Scale) {
+            assert_eq!(super::scale_value(n, format), (expected_value, expected_scale));
+        }
+
+        #[track_caller]
+        fn test_decimal(n: f64, expected_value: f64, expected_scale: Scale) {
+            test(n, BytesFormat::Decimal, expected_value, expected_scale);
+        }
+
+        test_decimal(1., 1., Scale::One);
+        test_decimal(1_000., 1., Scale::Kilo);
+        test_decimal(1_000_000., 1., Scale::Mega);
+        test_decimal(1_000_000_000., 1., Scale::Giga);
+        test_decimal(1_000_000_000_000., 1., Scale::Tera);
+        test_decimal(1_000_000_000_000_000., 1., Scale::Peta);
+    }
+}

--- a/src/util/miri.rs
+++ b/src/util/miri.rs
@@ -1,0 +1,19 @@
+//! Makes Miri more pleasant.
+
+#![allow(unused_variables)]
+
+// https://github.com/rust-lang/miri/blob/master/tests/utils/miri_extern.rs
+#[cfg(miri)]
+extern "Rust" {
+    fn miri_static_root(ptr: *const u8);
+}
+
+#[inline]
+pub fn leak<T: ?Sized>(ptr: *const T) {
+    // SAFETY: Miri will catch invalid pointer usage here, so make this pleasant
+    // to use outside of Miri since leaking memory is safe.
+    #[cfg(miri)]
+    unsafe {
+        miri_static_root(ptr.cast());
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -15,6 +15,7 @@ pub use {std::sync::atomic::AtomicUsize as SharedCount, usize as LocalCount};
 
 pub mod fmt;
 pub mod miri;
+pub mod sync;
 
 /// Public-in-private type like `()` but meant to be externally-unreachable.
 ///
@@ -22,6 +23,11 @@ pub mod miri;
 /// working with `()` unintentionally.
 #[non_exhaustive]
 pub struct Unit;
+
+/// Prevents false sharing by aligning to the cache line.
+#[derive(Clone, Copy)]
+#[repr(align(64))]
+pub struct CachePadded<T>(pub T);
 
 /// Makes the wrapped value [`Send`] + [`Sync`] even though it isn't.
 pub struct SyncWrap<T> {

--- a/src/util/sync.rs
+++ b/src/util/sync.rs
@@ -1,0 +1,127 @@
+//! Synchronization utilities.
+
+#![cfg(target_os = "macos")]
+
+use std::{
+    marker::PhantomData,
+    sync::atomic::{Ordering::*, *},
+};
+
+use libc::pthread_key_t;
+
+const KEY_UNINIT: pthread_key_t = 0;
+
+/// Thread-local key accessed via
+/// [`pthread_getspecific`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_getspecific.html).
+pub(crate) struct PThreadKey<T: 'static> {
+    value: AtomicPThreadKey,
+    marker: PhantomData<&'static T>,
+}
+
+impl<T> PThreadKey<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        Self { value: AtomicPThreadKey::new(KEY_UNINIT), marker: PhantomData }
+    }
+
+    #[inline]
+    pub fn get(&self) -> Option<&'static T> {
+        match self.value.load(Relaxed) {
+            KEY_UNINIT => None,
+            key => unsafe { libc::pthread_getspecific(key).cast::<T>().as_ref() },
+        }
+    }
+
+    #[inline]
+    pub fn set(&self, value: &'static T) {
+        let shared_key = &self.value;
+        let mut local_key = shared_key.load(Relaxed);
+
+        // Race against other threads to initialize `shared_key`.
+        if local_key == KEY_UNINIT {
+            if unsafe { libc::pthread_key_create(&mut local_key, None) } == 0 {
+                // Race to store our key into the global instance.
+                //
+                // On failure, delete our key and use the winner's key.
+                if let Err(their_key) =
+                    shared_key.compare_exchange(KEY_UNINIT, local_key, Relaxed, Relaxed)
+                {
+                    // SAFETY: No other thread is accessing this key.
+                    unsafe { libc::pthread_key_delete(local_key) };
+
+                    local_key = their_key;
+                }
+            } else {
+                // On create failure, check if another thread succeeded.
+                local_key = shared_key.load(Relaxed);
+                if local_key == KEY_UNINIT {
+                    return;
+                }
+            }
+        }
+
+        // SAFETY: The key has been created by us or another thread.
+        unsafe { libc::pthread_setspecific(local_key, value as *const T as _) };
+    }
+}
+
+/// Alias to the atomic equivalent of `pthread_key_t`.
+pub(crate) type AtomicPThreadKey = Atomic<pthread_key_t>;
+
+/// Alias to the atomic equivalent of `T`.
+pub(crate) type Atomic<T> = <T as WithAtomic>::Atomic;
+
+/// A type with an associated atomic type.
+pub(crate) trait WithAtomic {
+    type Atomic;
+}
+
+#[cfg(target_has_atomic = "ptr")]
+impl WithAtomic for usize {
+    type Atomic = AtomicUsize;
+}
+
+#[cfg(target_has_atomic = "ptr")]
+impl WithAtomic for isize {
+    type Atomic = AtomicIsize;
+}
+
+#[cfg(target_has_atomic = "8")]
+impl WithAtomic for u8 {
+    type Atomic = AtomicU8;
+}
+
+#[cfg(target_has_atomic = "8")]
+impl WithAtomic for i8 {
+    type Atomic = AtomicI8;
+}
+
+#[cfg(target_has_atomic = "16")]
+impl WithAtomic for u16 {
+    type Atomic = AtomicU16;
+}
+
+#[cfg(target_has_atomic = "16")]
+impl WithAtomic for i16 {
+    type Atomic = AtomicI16;
+}
+
+#[cfg(target_has_atomic = "32")]
+impl WithAtomic for u32 {
+    type Atomic = AtomicU32;
+}
+
+#[cfg(target_has_atomic = "32")]
+impl WithAtomic for i32 {
+    type Atomic = AtomicI32;
+}
+
+#[cfg(target_has_atomic = "64")]
+impl WithAtomic for u64 {
+    type Atomic = AtomicU64;
+}
+
+#[cfg(target_has_atomic = "64")]
+impl WithAtomic for i64 {
+    type Atomic = AtomicI64;
+}


### PR DESCRIPTION
This adds `AllocProfiler`, an allocator implementation that tracks the number of allocations and bytes allocated during benchmarks. It can wrap any `GlobalAlloc`, such as `mimalloc`.

[Example benchmark output: ![Screen Shot 2023-12-11 at 05 34 17](https://github.com/nvzqz/divan/assets/10367662/e0ea7a6a-dbc3-4dec-85ad-21c30ae94d94)](https://github.com/nvzqz/divan/actions/runs/7166109784/job/19509433332#step:4:280)
