### PR TITLE
macros: symlink license texts

### DIFF
--- a/macros/LICENSE-APACHE
+++ b/macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/macros/LICENSE-MIT
+++ b/macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
The license files need to be included for distribution, but since divan and divan-macros share a repository they only end up published with the main `divan` crate.

```
divan/macros on  add-license [+] is 📦 v0.1.14 via 🦀 v1.76.0
⬢ [fedora:39] ❯ cargo package --no-verify --allow-dirty
   Packaging divan-macros v0.1.14 (/home/michel/src/github/nvzqz/divan/macros)
    Packaged 7 files, 52.5KiB (14.7KiB compressed)

divan/macros on  add-license [+] is 📦 v0.1.14 via 🦀 v1.76.0
⬢ [fedora:39] ❯ tar tf ../target/package/divan-macros-0.1.14.crate | grep LICENSE
divan-macros-0.1.14/LICENSE-APACHE
divan-macros-0.1.14/LICENSE-MIT
```