### PR TITLE
Allow bench_refs() and bench_local_refs() to capture input lifetimes

### DIFF
--- a/examples/benches/string.rs
+++ b/examples/benches/string.rs
@@ -178,3 +178,19 @@ fn to_uppercase<G: GenString>(bencher: Bencher, len: usize) {
         .input_counter(BytesCount::of_str)
         .bench_local_refs(|s| s.to_uppercase());
 }
+
+#[divan::bench(
+    types = [Ascii, Unicode],
+    args = LENS,
+)]
+fn matches<G: GenString>(bencher: Bencher, len: usize) {
+    let mut gen = G::default();
+    // The return value of the closure passed to bench_refs/bench_local_refs
+    // is allowed to capture the input lifetime - in this example, its input
+    // is a &'a String, and its output a Vec<&'a str>.
+    bencher
+        .counter(CharsCount::new(len))
+        .with_inputs(|| gen.gen_string(len))
+        .input_counter(BytesCount::of_str)
+        .bench_local_refs(|s| s.matches(|c: char| c.is_ascii_digit()).collect::<Vec<_>>());
+}

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -417,12 +417,12 @@ where
     ///         });
     /// }
     /// ```
-    pub fn bench_refs<O, B>(self, benched: B)
+    pub fn bench_refs<'i, O, B>(self, benched: B)
     where
-        B: Fn(&mut I) -> O + Sync,
+        I: 'i,
+        B: Fn(&'i mut I) -> O + Sync,
         GenI: Fn() -> I + Sync,
     {
-        // TODO: Allow `O` to reference `&mut I` as long as `I` outlives `O`.
         self.context.bench_loop_threaded(
             self.config.gen_input,
             |input| {
@@ -463,11 +463,11 @@ where
     ///         });
     /// }
     /// ```
-    pub fn bench_local_refs<O, B>(self, mut benched: B)
+    pub fn bench_local_refs<'i, O, B>(self, mut benched: B)
     where
-        B: FnMut(&mut I) -> O,
+        I: 'i,
+        B: FnMut(&'i mut I) -> O,
     {
-        // TODO: Allow `O` to reference `&mut I` as long as `I` outlives `O`.
         self.context.bench_loop_local(
             self.config.gen_input,
             |input| {


### PR DESCRIPTION
This allows benchmarks using bench_refs() and bench_local_refs() to capture the input lifetimes, as was already suggested by TODO comments in the code.

By naming the input lifetime, the output type `O` is allowed to capture this lifetime. The `I: 'i` condition for `&'i mut I` must be made explicit now with named `'i`, or the code won't compile.

First commit adds tests that don't compile, second commit makes them compile.