### PR TITLE
Standard deviation for time samples

### DIFF
--- a/src/counter/collection.rs
+++ b/src/counter/collection.rs
@@ -40,6 +40,21 @@ impl CounterCollection {
         (sum / counts.len() as u128) as MaxCountUInt
     }
 
+    pub(crate) fn stddev_count(
+        &self,
+        counter_kind: KnownCounterKind,
+        mean: MaxCountUInt,
+    ) -> MaxCountUInt {
+        let counts = self.counts(counter_kind);
+
+        let mean = mean as i128;
+        let sum: u128 =
+            counts.iter().map(|&c| ((c as i128 - mean).abs() as u128).pow(2)).sum::<u128>()
+                / counts.len() as u128;
+
+        (sum as f64).sqrt() as MaxCountUInt
+    }
+
     #[inline]
     pub(crate) fn uses_input_counts(&self, counter_kind: KnownCounterKind) -> bool {
         self.info(counter_kind).count_input.is_some()

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -52,6 +52,9 @@ pub(crate) struct StatsSet<T> {
 
     /// Associated with average time taken by all iterations.
     pub mean: T,
+
+    /// Associated with the standard deviation of time taken by all iterations.
+    pub stddev: T,
 }
 
 impl StatsSet<f64> {

--- a/src/time/fine_duration.rs
+++ b/src/time/fine_duration.rs
@@ -6,6 +6,7 @@ use crate::util;
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub(crate) struct FineDuration {
+    /// picoseconds
     pub picos: u128,
 }
 
@@ -133,6 +134,16 @@ impl FineDuration {
             self
         } else {
             self.min(other)
+        }
+    }
+
+    /// Returns the absolute difference between two durations.
+    #[inline]
+    pub fn abs_diff(self, other: Self) -> Self {
+        if self > other {
+            FineDuration { picos: self.picos - other.picos }
+        } else {
+            FineDuration { picos: other.picos - self.picos }
         }
     }
 }

--- a/src/tree_painter.rs
+++ b/src/tree_painter.rs
@@ -298,6 +298,7 @@ impl TreePainter {
                 TreeColumn::Slowest => &stats.time.slowest,
                 TreeColumn::Median => &stats.time.median,
                 TreeColumn::Mean => &stats.time.mean,
+                TreeColumn::StandardDeviation => &stats.time.stddev,
                 TreeColumn::Samples => &stats.sample_count,
                 TreeColumn::Iters => &stats.iter_count,
             };
@@ -379,16 +380,17 @@ pub(crate) enum TreeColumn {
     Slowest,
     Median,
     Mean,
+    StandardDeviation,
     Samples,
     Iters,
 }
 
 impl TreeColumn {
-    pub const COUNT: usize = 6;
+    pub const COUNT: usize = 7;
 
     pub const ALL: [Self; Self::COUNT] = {
         use TreeColumn::*;
-        [Fastest, Slowest, Median, Mean, Samples, Iters]
+        [Fastest, Slowest, Median, Mean, StandardDeviation, Samples, Iters]
     };
 
     #[inline]
@@ -415,6 +417,7 @@ impl TreeColumn {
             Self::Slowest => "slowest",
             Self::Median => "median",
             Self::Mean => "mean",
+            Self::StandardDeviation => "std dev",
             Self::Samples => "samples",
             Self::Iters => "iters",
         }
@@ -433,6 +436,7 @@ impl TreeColumn {
             Self::Slowest => Some(&stats.slowest),
             Self::Median => Some(&stats.median),
             Self::Mean => Some(&stats.mean),
+            Self::StandardDeviation => Some(&stats.stddev),
             Self::Samples | Self::Iters => None,
         }
     }


### PR DESCRIPTION
Hey, just started using your library today and I really like it. A lot better than the built-in thing.

One (imo vital) statistic that I found missing is the standard deviation, so started working on that one. It's not finished yet, but feel free to correct me on the way so I wouldn't waste time on something you don't want in the lib.

Alternatively to standard deviation we could do sample variance (in my opinion it's less readable, but I found it in the roadmap of this library) or standard error.