### PR TITLE
Add Golang benchmark output format

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,13 +25,12 @@ pub(crate) fn command() -> Command {
 
     // Custom arguments not supported by libtest:
     // - bytes-format
+    // - output-format
     // - sample-count
     // - sample-size
     // - timer
     // - sort
     // - sortr
-
-    // TODO: `--format <pretty|terse>`
 
     let mut cmd = Command::new("divan");
 
@@ -56,6 +55,13 @@ pub(crate) fn command() -> Command {
                 .conflicts_with("list"),
         )
         .arg(flag("list").help("Lists benchmarks").conflicts_with("test"))
+        .arg(
+            option("output-format")
+                .env("DIVAN_OUTPUT_FORMAT")
+                .value_name("tree|golang")
+                .help("Set the output format for benchmark results")
+                .value_parser(value_parser!(crate::config::OutputFormat))
+        )
         .arg(
             option("color")
                 .value_name("WHEN")
@@ -190,6 +196,20 @@ impl ValueEnum for TimerKind {
         let name = match self {
             Self::Os => "os",
             Self::Tsc => "tsc",
+        };
+        Some(PossibleValue::new(name))
+    }
+}
+
+impl ValueEnum for crate::config::OutputFormat {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Tree, Self::Golang]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        let name = match self {
+            Self::Tree => "tree",
+            Self::Golang => "golang",
         };
         Some(PossibleValue::new(name))
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -182,3 +182,14 @@ impl SortingAttr {
         Ordering::Equal
     }
 }
+
+/// The output format for benchmark results.
+#[derive(Clone, Copy, Default)]
+pub(crate) enum OutputFormat {
+    /// Tree-style output (default).
+    #[default]
+    Tree,
+
+    /// Golang benchmark compatible output.
+    Golang,
+}

--- a/src/divan.rs
+++ b/src/divan.rs
@@ -9,18 +9,74 @@ use crate::{
     benchmark::BenchOptions,
     config::{
         filter::{Filter, FilterSet},
-        Action, ParsedSeconds, RunIgnored, SortingAttr,
+        Action, OutputFormat, ParsedSeconds, RunIgnored, SortingAttr,
     },
     counter::{
         BytesCount, BytesFormat, CharsCount, CyclesCount, IntoCounter,
         ItemsCount, MaxCountUInt, PrivBytesFormat,
     },
     entry::{AnyBenchEntry, BenchEntryRunner, EntryTree},
+    golang_painter::GolangPainter,
     time::{Timer, TimerKind},
     tree_painter::{TreeColumn, TreePainter},
     util::{self, thread::ThreadPool, IntoRegex},
     Bencher,
 };
+
+/// Painter abstraction for different output formats.
+enum Painter {
+    Tree(TreePainter),
+    Golang(GolangPainter),
+}
+
+impl Painter {
+    fn start_parent(&mut self, name: &str, is_last: bool) {
+        match self {
+            Painter::Tree(p) => p.start_parent(name, is_last),
+            Painter::Golang(p) => p.start_parent(name, is_last),
+        }
+    }
+
+    fn finish_parent(&mut self) {
+        match self {
+            Painter::Tree(p) => p.finish_parent(),
+            Painter::Golang(p) => p.finish_parent(),
+        }
+    }
+
+    fn ignore_leaf(&mut self, name: &str, is_last: bool) {
+        match self {
+            Painter::Tree(p) => p.ignore_leaf(name, is_last),
+            Painter::Golang(p) => p.ignore_leaf(name, is_last),
+        }
+    }
+
+    fn start_leaf(&mut self, name: &str, is_last: bool) {
+        match self {
+            Painter::Tree(p) => p.start_leaf(name, is_last),
+            Painter::Golang(p) => p.start_leaf(name, is_last),
+        }
+    }
+
+    fn finish_empty_leaf(&mut self) {
+        match self {
+            Painter::Tree(p) => p.finish_empty_leaf(),
+            Painter::Golang(p) => p.finish_empty_leaf(),
+        }
+    }
+
+    fn finish_leaf(
+        &mut self,
+        is_last: bool,
+        stats: &crate::stats::Stats,
+        bytes_format: BytesFormat,
+    ) {
+        match self {
+            Painter::Tree(p) => p.finish_leaf(is_last, stats, bytes_format),
+            Painter::Golang(p) => p.finish_leaf(is_last, stats, bytes_format),
+        }
+    }
+}
 
 /// The benchmark runner.
 #[derive(Default)]
@@ -31,6 +87,7 @@ pub struct Divan {
     sorting_attr: SortingAttr,
     color: ColorChoice,
     bytes_format: BytesFormat,
+    output_format: OutputFormat,
     filters: FilterSet,
     run_ignored: RunIgnored,
     bench_options: BenchOptions<'static>,
@@ -163,25 +220,32 @@ impl Divan {
         let shared_context =
             SharedContext { action, timer, thread_pool: ThreadPool::new() };
 
-        let column_widths = if action.is_bench() {
-            TreeColumn::ALL.map(|column| {
-                if column.is_last() {
-                    // The last column doesn't use padding.
-                    0
+        let painter = match self.output_format {
+            OutputFormat::Tree => {
+                let column_widths = if action.is_bench() {
+                    TreeColumn::ALL.map(|column| {
+                        if column.is_last() {
+                            // The last column doesn't use padding.
+                            0
+                        } else {
+                            EntryTree::common_column_width(&tree, column)
+                        }
+                    })
                 } else {
-                    EntryTree::common_column_width(&tree, column)
-                }
-            })
-        } else {
-            [0; TreeColumn::COUNT]
+                    [0; TreeColumn::COUNT]
+                };
+
+                Painter::Tree(TreePainter::new(
+                    EntryTree::max_name_span(&tree, 0),
+                    column_widths,
+                ))
+            }
+            OutputFormat::Golang => Painter::Golang(GolangPainter::new()),
         };
 
-        let tree_painter = RefCell::new(TreePainter::new(
-            EntryTree::max_name_span(&tree, 0),
-            column_widths,
-        ));
+        let painter = RefCell::new(painter);
 
-        self.run_tree(action, &tree, &shared_context, None, &tree_painter);
+        self.run_tree(action, &tree, &shared_context, None, &painter);
     }
 
     /// Emits the entries in `tree` for the purpose of `--list --format terse`.
@@ -231,7 +295,7 @@ impl Divan {
         tree: &[EntryTree],
         shared_context: &SharedContext,
         parent_options: Option<&BenchOptions>,
-        tree_painter: &RefCell<TreePainter>,
+        painter: &RefCell<Painter>,
     ) {
         for (i, child) in tree.iter().enumerate() {
             let is_last = i == tree.len() - 1;
@@ -261,21 +325,21 @@ impl Divan {
                     args.as_deref(),
                     shared_context,
                     options,
-                    tree_painter,
+                    painter,
                     is_last,
                 ),
                 EntryTree::Parent { children, .. } => {
-                    tree_painter.borrow_mut().start_parent(name, is_last);
+                    painter.borrow_mut().start_parent(name, is_last);
 
                     self.run_tree(
                         action,
                         children,
                         shared_context,
                         options,
-                        tree_painter,
+                        painter,
                     );
 
-                    tree_painter.borrow_mut().finish_parent();
+                    painter.borrow_mut().finish_parent();
                 }
             }
         }
@@ -288,7 +352,7 @@ impl Divan {
         bench_arg_names: Option<&[&&str]>,
         shared_context: &SharedContext,
         entry_options: Option<&BenchOptions>,
-        tree_painter: &RefCell<TreePainter>,
+        painter: &RefCell<Painter>,
         is_last_entry: bool,
     ) {
         use crate::benchmark::BenchContext;
@@ -306,17 +370,15 @@ impl Divan {
         };
 
         if self.should_ignore(options.ignore.unwrap_or_default()) {
-            tree_painter
-                .borrow_mut()
-                .ignore_leaf(entry_display_name, is_last_entry);
+            painter.borrow_mut().ignore_leaf(entry_display_name, is_last_entry);
             return;
         }
 
         // Paint empty leaf when simply listing.
         if action.is_list() {
-            let mut tree_painter = tree_painter.borrow_mut();
-            tree_painter.start_leaf(entry_display_name, is_last_entry);
-            tree_painter.finish_empty_leaf();
+            let mut painter = painter.borrow_mut();
+            painter.start_leaf(entry_display_name, is_last_entry);
+            painter.finish_empty_leaf();
             return;
         }
 
@@ -348,11 +410,11 @@ impl Divan {
              is_last_bench: bool,
              with_bencher: &dyn Fn(Bencher)| {
                 if has_thread_branches {
-                    tree_painter
+                    painter
                         .borrow_mut()
                         .start_parent(bench_display_name, is_last_bench);
                 } else {
-                    tree_painter
+                    painter
                         .borrow_mut()
                         .start_leaf(bench_display_name, is_last_bench);
                 }
@@ -365,7 +427,7 @@ impl Divan {
                     };
 
                     if has_thread_branches {
-                        tree_painter.borrow_mut().start_leaf(
+                        painter.borrow_mut().start_leaf(
                             &format!("t={thread_count}"),
                             is_last_thread_count,
                         );
@@ -389,18 +451,18 @@ impl Divan {
 
                     if should_compute_stats {
                         let stats = bench_context.compute_stats();
-                        tree_painter.borrow_mut().finish_leaf(
+                        painter.borrow_mut().finish_leaf(
                             is_last_thread_count,
                             &stats,
                             self.bytes_format,
                         );
                     } else {
-                        tree_painter.borrow_mut().finish_empty_leaf();
+                        painter.borrow_mut().finish_empty_leaf();
                     }
                 }
 
                 if has_thread_branches {
-                    tree_painter.borrow_mut().finish_parent();
+                    painter.borrow_mut().finish_parent();
                 }
             };
 
@@ -410,7 +472,7 @@ impl Divan {
             }
 
             BenchEntryRunner::Args(bench_runner) => {
-                tree_painter
+                painter
                     .borrow_mut()
                     .start_parent(entry_display_name, is_last_entry);
 
@@ -428,7 +490,7 @@ impl Divan {
                     });
                 }
 
-                tree_painter.borrow_mut().finish_parent();
+                painter.borrow_mut().finish_parent();
             }
         }
     }
@@ -538,6 +600,10 @@ impl Divan {
         } else if let Some(&sorting_attr) = matches.get_one("sort") {
             self.reverse_sort = false;
             self.sorting_attr = sorting_attr;
+        }
+
+        if let Some(&output_format) = matches.get_one("output-format") {
+            self.output_format = output_format;
         }
 
         if let Some(&sample_count) = matches.get_one("sample-count") {

--- a/src/golang_painter.rs
+++ b/src/golang_painter.rs
@@ -1,0 +1,139 @@
+//! Golang benchmark format output.
+
+use crate::{
+    alloc::AllocOp,
+    counter::{BytesFormat, KnownCounterKind},
+    stats::Stats,
+};
+
+mod picos {
+    pub const NANOS: u128 = 1_000;
+    pub const SEC: u128 = 1_000_000_000_000;
+}
+
+/// Paints output in Golang benchmark format.
+///
+/// Go benchmark format:
+/// BenchmarkName-8         1000000              1234 ns/op            123 B/op          4 allocs/op
+///
+/// Format breakdown:
+/// - BenchmarkName-N (N is number of threads)
+/// - Iteration count (total iterations across all samples)
+/// - Average time per operation with unit
+/// - Optional throughput metrics (B/op for bytes/items, allocs/op for allocations)
+pub(crate) struct GolangPainter {
+    /// Current path for nested benchmarks
+    current_path: Vec<String>,
+}
+
+impl GolangPainter {
+    pub fn new() -> Self {
+        Self { current_path: Vec::new() }
+    }
+
+    /// Get the full benchmark name from the current path
+    fn get_benchmark_name(&self) -> String {
+        if self.current_path.is_empty() {
+            "Benchmark".to_string()
+        } else {
+            format!("Benchmark{}", self.current_path.join("/"))
+        }
+    }
+}
+
+fn rewrite(s: &str) -> String {
+    let mut result = String::new();
+
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            result.push('_');
+        } else if !is_printable(ch) {
+            // Escape non-printable characters
+            let escaped = format!("{:?}", ch);
+            // Remove surrounding quotes from the debug representation
+            result.push_str(&escaped[1..escaped.len() - 1]);
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+fn is_printable(ch: char) -> bool {
+    !ch.is_control() || ch == '\t'
+}
+impl GolangPainter {
+    /// Enter a parent node.
+    pub fn start_parent(&mut self, name: &str, _is_last: bool) {
+        self.current_path.push(rewrite(name));
+    }
+
+    /// Exit the current parent node.
+    pub fn finish_parent(&mut self) {
+        self.current_path.pop();
+    }
+
+    /// Indicate that the next child node was ignored.
+    pub fn ignore_leaf(&mut self, name: &str, _is_last: bool) {}
+
+    /// Enter a leaf node.
+    pub fn start_leaf(&mut self, name: &str, _is_last: bool) {
+        self.current_path.push(rewrite(name));
+    }
+
+    /// Exit the current leaf node.
+    pub fn finish_empty_leaf(&mut self) {
+        self.current_path.pop();
+        // In golang format, we don't output anything for empty leaves during listing
+    }
+
+    /// Exit the current leaf node, emitting statistics in Golang format.
+    pub fn finish_leaf(
+        &mut self,
+        _is_last: bool,
+        stats: &Stats,
+        _bytes_format: BytesFormat,
+    ) {
+        let benchmark_name = self.get_benchmark_name();
+        self.current_path.pop();
+
+        // Calculate total iterations
+        let total_iters = stats.sample_count as u64 * stats.iter_count;
+
+        // Get mean time in nanoseconds
+        let mean_picos = stats.time.mean.picos;
+        let mean_ns = mean_picos as f64 / picos::NANOS as f64;
+
+        // Format: BenchmarkName-1         1000000              1234 ns/op
+        print!(
+            "{:<40} {:>10} {:>20.1} ns/op",
+            format!("{}-1", benchmark_name),
+            total_iters,
+            mean_ns
+        );
+
+        // Check for bytes or items throughput
+        for counter_kind in [KnownCounterKind::Items, KnownCounterKind::Bytes] {
+            if let Some(counter_stats) = stats.get_counts(counter_kind) {
+                let count = counter_stats.mean;
+                if count > 0 && !stats.time.mean.is_zero() {
+                    // Calculate throughput per operation
+                    let time_secs =
+                        stats.time.mean.picos as f64 / picos::SEC as f64;
+                    let throughput_per_sec = count as f64 / time_secs;
+                    print!(" {:>20.0} B/op", throughput_per_sec);
+                    break;
+                }
+            }
+        }
+
+        // Add allocation information if available
+        let alloc_tally = stats.alloc_tallies.get(AllocOp::Alloc);
+        if !alloc_tally.count.mean.is_nan() && alloc_tally.count.mean > 0.0 {
+            print!(" {:>15.0} allocs/op", alloc_tally.count.mean);
+        }
+
+        println!();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod compile_fail;
 mod config;
 mod divan;
 mod entry;
+mod golang_painter;
 mod stats;
 mod time;
 mod tree_painter;


### PR DESCRIPTION
This enables outputting benchmark data in the Golang benchmark format. The benefit of this is that it enables a lot of great tooling (see https://www.bwplotka.dev/2024/go-microbenchmarks-benchstat/, etc).

Example output:

```
BenchmarkProxy/bench_build/case=bbr-1   10000000               1911.6 ns/op
BenchmarkProxy/bench_build/case=header-1   10000000               1805.9 ns/op
BenchmarkProxy/bench_build/case=simple_access-1   10000000               1670.5 ns/op
```

With `benchstat` this can be summarized or compared against others like

```
name                                    time/op
Proxy/bench_build/case=bbr-1            1.91µs ± 0%
Proxy/bench_build/case=header-1         1.81µs ± 0%
Proxy/bench_build/case=simple_access-1  1.67µs ± 0%
```